### PR TITLE
[FIX]: 인증번호 메시지 내용 수정, 1분 내 인증번호 발송 시도 시 막기

### DIFF
--- a/src/main/java/com/barogagi/approval/controller/ApprovalController.java
+++ b/src/main/java/com/barogagi/approval/controller/ApprovalController.java
@@ -28,6 +28,7 @@ public class ApprovalController {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "A102", description = "인증문자 발송 중 오류가 발생하였습니다."),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "A103", description = "인증번호 발송에 실패하였습니다."),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "A100", description = "API SECRET KEY 불일치"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "A104", description = "1분 후 다시 시도해주세요."),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "오류가 발생하였습니다.")
             })
     @PostMapping("/send")

--- a/src/main/java/com/barogagi/approval/dto/ApprovalCheckDTO.java
+++ b/src/main/java/com/barogagi/approval/dto/ApprovalCheckDTO.java
@@ -1,0 +1,15 @@
+package com.barogagi.approval.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ApprovalCheckDTO {
+    private String tel;
+    private String completeYn;
+    private String type;
+    private LocalDateTime regDate;
+}

--- a/src/main/java/com/barogagi/approval/repository/ApprovalNumInfoRepository.java
+++ b/src/main/java/com/barogagi/approval/repository/ApprovalNumInfoRepository.java
@@ -2,9 +2,15 @@ package com.barogagi.approval.repository;
 
 import com.barogagi.approval.domain.ApprovalNumInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface ApprovalNumInfoRepository extends JpaRepository<ApprovalNumInfo, Integer> {
 
     Optional<ApprovalNumInfo> findTopByTelAndTypeAndCompleteYnOrderByRegDateDesc(
@@ -19,4 +25,17 @@ public interface ApprovalNumInfoRepository extends JpaRepository<ApprovalNumInfo
             String completeYn,
             String authCode
     );
+
+    @Query(value = """
+            SELECT a
+            FROM ApprovalNumInfo a
+            WHERE a.tel = :tel
+            AND a.completeYn = :completeYn
+            AND a.type = :type
+            AND a.regDate >= :time
+            """)
+    List<ApprovalNumInfo> findApprovalNumInfo(@Param("tel") String tel,
+                                              @Param("completeYn") String completeYn,
+                                              @Param("type") String type,
+                                              @Param("time")LocalDateTime time);
 }

--- a/src/main/java/com/barogagi/approval/service/ApprovalService.java
+++ b/src/main/java/com/barogagi/approval/service/ApprovalService.java
@@ -56,7 +56,7 @@ public class ApprovalService {
         // 인증번호 메시지 발송
         SendSmsVO sendSmsVO = new SendSmsVO();
         sendSmsVO.setRecipientTel(approvalSendVO.getTel());
-        String messageContent = "인증번호는 [" + authCode + "] 입니다.";
+        String messageContent = "[핏플(fitpl)]\r\n인증번호는 [" + authCode + "] 입니다.";
         sendSmsVO.setMessageContent(messageContent);
         boolean sendMessageResult = smsSendService.sendSms(sendSmsVO);
 

--- a/src/main/java/com/barogagi/approval/service/ApprovalService.java
+++ b/src/main/java/com/barogagi/approval/service/ApprovalService.java
@@ -1,5 +1,7 @@
 package com.barogagi.approval.service;
 
+import com.barogagi.approval.domain.ApprovalNumInfo;
+import com.barogagi.approval.dto.ApprovalCheckDTO;
 import com.barogagi.approval.exception.ApprovalException;
 import com.barogagi.approval.vo.ApprovalCompleteVO;
 import com.barogagi.approval.vo.ApprovalSendVO;
@@ -13,6 +15,9 @@ import com.barogagi.util.Validator;
 import com.barogagi.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +42,18 @@ public class ApprovalService {
             throw new ApprovalException(ErrorCode.EMPTY_DATA);
         }
 
-        // 3. 처리
+        // 3. 1분 내로 시도했을 경우 잠시 후 발송
+        ApprovalCheckDTO approvalCheckDTO = new ApprovalCheckDTO();
+        approvalCheckDTO.setTel(encryptUtil.hashEncodeString(approvalSendVO.getTel().replaceAll("[^0-9]", "")));
+        approvalCheckDTO.setCompleteYn("N");
+        approvalCheckDTO.setType(approvalSendVO.getType());
+        approvalCheckDTO.setRegDate(LocalDateTime.now().minusMinutes(1));
+        List<ApprovalNumInfo> approvalCheckDTOList = approvalTxService.findApprovalNumInfo(approvalCheckDTO);
+        if(!approvalCheckDTOList.isEmpty()) {
+            throw new ApprovalException(ErrorCode.NOT_ACCESS_SEND_APPROVAL);
+        }
+
+        // 4. 처리
         // 인증번호를 DB에 INSERT 전에, 전에 발송된 기록들은 flag UPDATE 처리
         ApprovalVO approvalVO = new ApprovalVO();
         approvalVO.setCompleteYn("N");
@@ -56,7 +72,7 @@ public class ApprovalService {
         // 인증번호 메시지 발송
         SendSmsVO sendSmsVO = new SendSmsVO();
         sendSmsVO.setRecipientTel(approvalSendVO.getTel());
-        String messageContent = "[핏플(fitpl)]\r\n인증번호는 [" + authCode + "] 입니다.";
+        String messageContent = "[핏플(fitpl)]\r\n인증번호: " + authCode;
         sendSmsVO.setMessageContent(messageContent);
         boolean sendMessageResult = smsSendService.sendSms(sendSmsVO);
 

--- a/src/main/java/com/barogagi/approval/service/ApprovalTxService.java
+++ b/src/main/java/com/barogagi/approval/service/ApprovalTxService.java
@@ -1,14 +1,15 @@
 package com.barogagi.approval.service;
 
 import com.barogagi.approval.domain.ApprovalNumInfo;
+import com.barogagi.approval.dto.ApprovalCheckDTO;
 import com.barogagi.approval.repository.ApprovalNumInfoRepository;
 import com.barogagi.approval.vo.ApprovalVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -62,5 +63,10 @@ public class ApprovalTxService {
         entity.setCompleteYn("Y");
         entity.setCompleteDate(LocalDateTime.now());
         return true;
+    }
+
+    public List<ApprovalNumInfo> findApprovalNumInfo(ApprovalCheckDTO approvalCheckDTO) {
+        return approvalNumInfoRepository.findApprovalNumInfo(approvalCheckDTO.getTel(),
+                approvalCheckDTO.getCompleteYn(), approvalCheckDTO.getType(), approvalCheckDTO.getRegDate());
     }
 }

--- a/src/main/java/com/barogagi/util/exception/ErrorCode.java
+++ b/src/main/java/com/barogagi/util/exception/ErrorCode.java
@@ -112,6 +112,7 @@ public enum ErrorCode {
     ERROR_SEND_APPROVAL(HttpStatus.INTERNAL_SERVER_ERROR, "A102", "인증문자 발송 중 오류가 발생하였습니다.", false),
     SUCCESS_CHECK_APPROVAL(HttpStatus.OK, "A200", "인증이 완료되었습니다.", false),
     FAIL_CHECK_APPROVAL(HttpStatus.BAD_REQUEST, "A300", "인증에 실패하였습니다.", false),
+    NOT_ACCESS_SEND_APPROVAL(HttpStatus.BAD_REQUEST, "A104", "1분 후 다시 시도해주세요.", false),
 
     // Schedule
     SUCCESS_SCHEDULE_CREATE(HttpStatus.CREATED, "S201", "일정 생성에 성공하였습니다.", false),


### PR DESCRIPTION
## Changed
> 간단한 설명 (예: 로그인 완료 후 세션 동기화 누락 문제 해결)
수정 내용
   - 예) 로그인 성공 시 `store.setSession()` 호출 추가
   - 예) 기존 세션 초기화 로직 정리
---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> 해당 PR 내용 관련해서 추후 해야할 일 

---
## Note
> 해당 PR관련해서 다른 작업자가 참고할 사항이 있다면 말해주세요!
> 예: npm i 로 oo 라이브 러리 설치 필요
