### PR TITLE
[FEAT/FIX] oAuth 관련 작업, 인증번호 발송 작업 수정 (#160)

### DIFF
--- a/src/main/java/com/barogagi/approval/service/ApprovalService.java
+++ b/src/main/java/com/barogagi/approval/service/ApprovalService.java
@@ -6,6 +6,7 @@ import com.barogagi.approval.exception.ApprovalException;
 import com.barogagi.approval.vo.ApprovalCompleteVO;
 import com.barogagi.approval.vo.ApprovalSendVO;
 import com.barogagi.approval.vo.ApprovalVO;
+import com.barogagi.properties.MessageSendProperties;
 import com.barogagi.response.ApiResponse;
 import com.barogagi.sendMessage.sms.dto.SendSmsVO;
 import com.barogagi.sendMessage.sms.service.SmsSendService;
@@ -29,6 +30,7 @@ public class ApprovalService {
     private final AuthCodeService authCodeService;
     private final SmsSendService smsSendService;
     private final ApprovalTxService approvalTxService;
+    private final MessageSendProperties messageSendProperties;
 
     public ApiResponse approvalTelSend(String apiSecretKey, ApprovalSendVO approvalSendVO) {
 
@@ -72,7 +74,7 @@ public class ApprovalService {
         // 인증번호 메시지 발송
         SendSmsVO sendSmsVO = new SendSmsVO();
         sendSmsVO.setRecipientTel(approvalSendVO.getTel());
-        String messageContent = "[핏플(fitpl)]\r\n인증번호: " + authCode;
+        String messageContent = messageSendProperties.getName() + "\r\n" + "인증번호: " + authCode;
         sendSmsVO.setMessageContent(messageContent);
         boolean sendMessageResult = smsSendService.sendSms(sendSmsVO);
 

--- a/src/main/java/com/barogagi/batch/service/MessageSendService.java
+++ b/src/main/java/com/barogagi/batch/service/MessageSendService.java
@@ -4,6 +4,7 @@ import com.barogagi.batch.dto.SendDTO;
 import com.barogagi.batch.entity.MessageOutbox;
 import com.barogagi.batch.vo.SendResult;
 import com.barogagi.member.domain.UserMembershipInfo;
+import com.barogagi.properties.MessageSendProperties;
 import com.barogagi.sendMessage.alimTalk.service.AlimTalkSendService;
 import com.barogagi.sendMessage.email.dto.SendMailDTO;
 import com.barogagi.sendMessage.email.service.EmailSendService;
@@ -23,12 +24,13 @@ public class MessageSendService {
 
     private final EncryptUtil encryptUtil;
 
+    private final MessageSendProperties messageSendProperties;
+
     private final AlimTalkSendService alimTalkSendService;
     private final SmsSendService smsSendService;
     private final EmailSendService emailSendService;
 
     // 알림톡 / 문자
-    private final String SERVICE_NAME = "핏플(fitpl)";
     private final String CANCEL_METHOD = "앱 접속 후 로그인";
 
     // 이메일
@@ -37,11 +39,13 @@ public class MessageSendService {
 
     public MessageSendService(Environment environment,
                               EncryptUtil encryptUtil,
+                              MessageSendProperties messageSendProperties,
                               AlimTalkSendService alimTalkSendService,
                               SmsSendService smsSendService,
                               EmailSendService emailSendService) {
         this.DIRECT_SEND_FROM = environment.getProperty("direct-send.from");
         this.encryptUtil = encryptUtil;
+        this.messageSendProperties = messageSendProperties;
         this.alimTalkSendService = alimTalkSendService;
         this.smsSendService = smsSendService;
         this.emailSendService = emailSendService;
@@ -61,7 +65,7 @@ public class MessageSendService {
 
         // 메시지에 들어갈 데이터 (공통)
         Map<String, String> variables = new HashMap<>();
-        variables.put("serviceName", SERVICE_NAME);
+        variables.put("serviceName", messageSendProperties.getName());
         variables.put("withdrawDay", String.valueOf(userMembershipInfo.getDelDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()));
         variables.put("cancelMethod", CANCEL_METHOD);
 
@@ -82,13 +86,13 @@ public class MessageSendService {
                     return smsSuccess ? new SendResult(true, null) : new SendResult(false, "SMS 발송 실패");
 
                 case EMAIL:
-                    variables.put("supportEmail", "support@fitpl.com");
-                    variables.put("companyKorName", "핏플");
-                    variables.put("bizNumber", "000-00-00000");
-                    variables.put("ceoName", "홍길동");
-                    variables.put("address", "서울특별시 OO구 OO로 00");
-                    variables.put("tel", "0000-0000");
-                    variables.put("companyEngName", "Fitpl");
+                    variables.put("supportEmail", messageSendProperties.getCompanyEmail());
+                    variables.put("companyKorName", messageSendProperties.getCompanyKorName());
+                    variables.put("bizNumber", messageSendProperties.getBusinessBizNumber());
+                    variables.put("ceoName", messageSendProperties.getCompanyCeoName());
+//                    variables.put("address", "서울특별시 OO구 OO로 00");
+                    variables.put("tel", messageSendProperties.getCompanyTel());
+                    variables.put("companyEngName", messageSendProperties.getCompanyEngName());
                     sendDTO.setVariables(variables);
 
                     SendMailDTO sendMailDTO = new SendMailDTO();

--- a/src/main/java/com/barogagi/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/barogagi/config/OAuth2LoginSuccessHandler.java
@@ -2,24 +2,34 @@ package com.barogagi.config;
 
 import com.barogagi.member.login.dto.LoginResponse;
 import com.barogagi.member.login.service.AuthService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final AuthService authService;
-    private final ObjectMapper objectMapper;
+    private final Environment environment;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest req, HttpServletResponse res,
@@ -32,17 +42,34 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         LoginResponse login = authService.loginAfterSignup(userId, "web-oauth");
 
-        res.setContentType("application/json;charset=UTF-8");
-        objectMapper.writeValue(res.getWriter(), Map.of(
-                "resultCode", login.tokens().resultCode(),
-                "message", login.tokens().message(),
-                "accessToken", login.tokens().accessToken(),
-                "accessTokenExpiresIn", login.tokens().accessTokenExpiresIn(),
-                "userId", userId,
-                "membershipNo", login.membershipNo(),
-                "refreshToken", login.tokens().refreshToken(),
-                "refreshTokenExpiresIn", login.tokens().refreshTokenExpiresIn()
-        ));
+        // 서버 종류
+        String[] profiles = environment.getActiveProfiles();
+        String serverType = (profiles.length > 0) ? profiles[0] : "";
+
+        // 서버별 주소
+        List<String> addresses = Arrays.asList(allowedOrigins.split(","));
+
+        String url = "";
+        if(serverType.equals("dev")) {  // 테스트 서버
+            url = addresses.get(1);
+        } else if(serverType.equals("prod")) {  // 실서버
+            url = addresses.get(2);
+        } else {  // 로컬 서버
+            url = addresses.get(0);
+        }
+
+        // 프론트로 redirect + 데이터 전달
+        String redirectUrl = url + "/oauth/success" +
+                "?resultCode=" + login.tokens().resultCode() +
+                "&message=" + URLEncoder.encode(login.tokens().message(), StandardCharsets.UTF_8) +
+                "&accessToken=" + login.tokens().accessToken() +
+                "&accessTokenExpiresIn=" + login.tokens().accessTokenExpiresIn() +
+                "&userId=" + userId +
+                "&membershipNo=" + login.membershipNo() +
+                "&refreshToken=" + login.tokens().refreshToken() +
+                "&refreshTokenExpiresIn=" + login.tokens().refreshTokenExpiresIn();
+
+        res.sendRedirect(redirectUrl);
     }
 
     private String extractUserId(Map<String, Object> attrs) {

--- a/src/main/java/com/barogagi/config/SecurityConfig.java
+++ b/src/main/java/com/barogagi/config/SecurityConfig.java
@@ -57,7 +57,9 @@ public class SecurityConfig {
             "/api/v1/home/regions/popular",  // 인기 지역 조회
             "/api/v1/verification-codes/**",  // 인증 번호 발송
             "/api/v1/withdrawal-reasons",  // 탈퇴 사유 조회
-            "api/v1/schedule/image/proxy"  // 일정 이미지 프록시 (외부 이미지 허용)
+            "api/v1/schedule/image/proxy",  // 일정 이미지 프록시 (외부 이미지 허용)
+            "/api/v1/oauth-link",
+            "**/oauth/success"  // oauth 로그인 성공 시
     };
 
     @Bean

--- a/src/main/java/com/barogagi/discord/dto/DiscordErrorMessage.java
+++ b/src/main/java/com/barogagi/discord/dto/DiscordErrorMessage.java
@@ -27,7 +27,7 @@ public class DiscordErrorMessage {
             String environment
     ) {
         return DiscordErrorMessage.builder()
-                .service("BAROGAGI-API")
+                .service("FITPL-API")
                 .environment(environment)
                 .uri(request.getRequestURI())
                 .method(request.getMethod())
@@ -47,7 +47,7 @@ public class DiscordErrorMessage {
             String stackTrace
     ) {
         return DiscordErrorMessage.builder()
-                .service("BAROGAGI-API")
+                .service("FITPL-API")
                 .environment(environment)
                 .uri(request.getRequestURI())
                 .method(request.getMethod())

--- a/src/main/java/com/barogagi/member/join/oauth/controller/OAuthController.java
+++ b/src/main/java/com/barogagi/member/join/oauth/controller/OAuthController.java
@@ -1,0 +1,38 @@
+package com.barogagi.member.join.oauth.controller;
+
+import com.barogagi.member.join.oauth.dto.OAuthLinkDTO;
+import com.barogagi.member.join.oauth.enums.Environment;
+import com.barogagi.member.join.oauth.enums.Type;
+import com.barogagi.member.join.oauth.service.OAuthService;
+import com.barogagi.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "OAuth", description = "OAuth 관련 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @Operation(summary = "OAuth Link 조회 기능", description = "OAuth Link 조회 기능입니다.",
+            responses =  {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "A100", description = "API KEY 불일치"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "L200", description = "조회 성공하였습니다."),
+            })
+    @GetMapping("/oauth-link")
+    public ApiResponse selectOAuthLink(@RequestHeader("API-KEY") String apiSecretKey,
+                                        @RequestParam Environment environment,
+                                        @RequestParam Type type) {
+
+        OAuthLinkDTO oAuthLinkDTO = new OAuthLinkDTO();
+        oAuthLinkDTO.setApiSecretKey(apiSecretKey);
+        oAuthLinkDTO.setEnvironment(environment);
+        oAuthLinkDTO.setType(type);
+
+        return oAuthService.selectOAuthLink(oAuthLinkDTO);
+    }
+}

--- a/src/main/java/com/barogagi/member/join/oauth/dto/OAuthLinkDTO.java
+++ b/src/main/java/com/barogagi/member/join/oauth/dto/OAuthLinkDTO.java
@@ -1,0 +1,14 @@
+package com.barogagi.member.join.oauth.dto;
+
+import com.barogagi.member.join.oauth.enums.Environment;
+import com.barogagi.member.join.oauth.enums.Type;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OAuthLinkDTO {
+    private String apiSecretKey;
+    private Type type;
+    private Environment environment;
+}

--- a/src/main/java/com/barogagi/member/join/oauth/enums/Environment.java
+++ b/src/main/java/com/barogagi/member/join/oauth/enums/Environment.java
@@ -1,0 +1,5 @@
+package com.barogagi.member.join.oauth.enums;
+
+public enum Environment {
+    LOCAL, TEST, PROD
+}

--- a/src/main/java/com/barogagi/member/join/oauth/enums/Type.java
+++ b/src/main/java/com/barogagi/member/join/oauth/enums/Type.java
@@ -1,0 +1,5 @@
+package com.barogagi.member.join.oauth.enums;
+
+public enum Type {
+    Google, Kakao, Naver
+}

--- a/src/main/java/com/barogagi/member/join/oauth/exception/OAuthException.java
+++ b/src/main/java/com/barogagi/member/join/oauth/exception/OAuthException.java
@@ -1,0 +1,12 @@
+package com.barogagi.member.join.oauth.exception;
+
+import com.barogagi.config.exception.BusinessException;
+import com.barogagi.util.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class OAuthException extends BusinessException {
+    public OAuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/barogagi/member/join/oauth/service/OAuthService.java
+++ b/src/main/java/com/barogagi/member/join/oauth/service/OAuthService.java
@@ -1,0 +1,74 @@
+package com.barogagi.member.join.oauth.service;
+
+import com.barogagi.member.join.oauth.dto.OAuthLinkDTO;
+import com.barogagi.member.join.oauth.enums.Environment;
+import com.barogagi.member.join.oauth.enums.Type;
+import com.barogagi.member.join.oauth.exception.OAuthException;
+import com.barogagi.response.ApiResponse;
+import com.barogagi.util.Validator;
+import com.barogagi.util.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final Validator validator;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
+    public ApiResponse selectOAuthLink(OAuthLinkDTO oAuthLinkDTO) {
+
+        // 1. API SECRET KEY 일치 여부 확인
+        if(!validator.apiSecretKeyCheck(oAuthLinkDTO.getApiSecretKey())) {
+            throw new OAuthException(ErrorCode.NOT_EQUAL_API_SECRET_KEY);
+        }
+
+        // 2. 서버별 주소
+        List<String> addresses = Arrays.asList(allowedOrigins.split(","));
+
+        // LOCAL
+        String localAddress = addresses.get(0);
+        // TEST
+        String testAddress = addresses.get(1);
+        // REAL
+        String realAddress = addresses.get(2);
+
+        // 3. OAuth Link
+        Environment environment = oAuthLinkDTO.getEnvironment();
+        Type type = oAuthLinkDTO.getType();
+        String uri = "/oauth2/authorization";
+        String link = "";
+
+        if(environment.equals(Environment.LOCAL)) {  // 로컬 서버
+            link = localAddress + uri;
+            link = switch (type) {
+                case Google -> link + "/google";
+                case Kakao -> link + "/kakao";
+                case Naver -> link + "/naver";
+            };
+        } else if(environment.equals(Environment.TEST)) {  // 테스트 서버
+            link = testAddress + uri;
+            link = switch (type) {
+                case Google -> link + "/google";
+                case Kakao -> link + "/kakao";
+                case Naver -> link + "/naver";
+            };
+        } else if(environment.equals(Environment.PROD)) {  // 실서버
+            link = realAddress + uri;
+            link = switch (type) {
+                case Google -> link + "/google";
+                case Kakao -> link + "/kakao";
+                case Naver -> link + "/naver";
+            };
+        }
+
+        return ApiResponse.resultData(link, "L200", "조회 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/barogagi/properties/MessageSendProperties.java
+++ b/src/main/java/com/barogagi/properties/MessageSendProperties.java
@@ -1,0 +1,40 @@
+package com.barogagi.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "service")
+public class MessageSendProperties {
+
+    // service.name
+    private String name = "핏플(fitpl)";
+
+    // service.kor-name
+    private String korName = "핏플";
+
+    // service.eng-name
+    private String engName;
+
+    // service.company.email
+    private String companyEmail;
+
+    // service.company.kor-name
+    private String companyKorName = "푸른핫가마";
+
+    // service.company.eng-name
+    private String companyEngName;
+
+    // service.company.tel
+    private String companyTel;
+
+    // service.business.biz.number
+    private String businessBizNumber;
+
+    // service.company.ceo-name
+    private String companyCeoName = "정은우";
+}

--- a/src/main/java/com/barogagi/sendMessage/email/service/AsyncSmtpMailService.java
+++ b/src/main/java/com/barogagi/sendMessage/email/service/AsyncSmtpMailService.java
@@ -1,5 +1,6 @@
 package com.barogagi.sendMessage.email.service;
 
+import com.barogagi.properties.MessageSendProperties;
 import com.barogagi.sendMessage.email.dto.SendMailDTO;
 import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;
@@ -17,6 +18,8 @@ import java.util.concurrent.CompletableFuture;
 @Service
 public class AsyncSmtpMailService {
 
+    private final MessageSendProperties messageSendProperties;
+
     private final String SMTP_HOST = "smtp.gmail.com";
     private final int SMTP_PORT = 587;
     private final String USERNAME; // Gmail 계정
@@ -24,9 +27,11 @@ public class AsyncSmtpMailService {
 
     private final int MAX_RETRY = 3;
 
-    public AsyncSmtpMailService(Environment environment) {
+    public AsyncSmtpMailService(Environment environment,
+                                MessageSendProperties messageSendProperties) {
         USERNAME = environment.getProperty("direct-send.from");
         PASSWORD = environment.getProperty("app.password");
+        this.messageSendProperties = messageSendProperties;
     }
 
     @Async
@@ -52,7 +57,7 @@ public class AsyncSmtpMailService {
             });
 
             Message message = new MimeMessage(session);
-            message.setFrom(new InternetAddress(from, "핏플(fitpl)", "UTF-8"));
+            message.setFrom(new InternetAddress(from, messageSendProperties.getName(), "UTF-8"));
             message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
             message.setSubject(subject);
             message.setContent(body, "text/html; charset=UTF-8");

--- a/src/main/java/com/barogagi/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/barogagi/util/exception/GlobalExceptionHandler.java
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
             BusinessException e,
             HttpServletRequest request
     ) {
-        if (isProd() && e.getErrorCode().isNotify()) {
+        if ((isDev() || isProd()) && e.getErrorCode().isNotify()) {
             discordNotifier.sendError(DiscordErrorMessage.from(e, request, activeProfile()));
         }
 
@@ -82,18 +82,8 @@ public class GlobalExceptionHandler {
         String key = e.getClass().getName() + request.getRequestURI();
 
         // Discord 알림 전송
-        if (isProd() && errorThrottle.shouldNotify(key)) {
-            discordNotifier.sendError(
-                    DiscordErrorMessage.builder()
-                            .service("BAROGAGI-API")
-                            .environment(activeProfile())
-                            .uri(request.getRequestURI())
-                            .method(request.getMethod())
-                            .exception(e.getClass().getSimpleName())
-                            .message(e.getMessage())
-                            .stackTrace(getStackTrace(e))
-                            .build()
-            );
+        if ((isDev() || isProd()) && errorThrottle.shouldNotify(key)) {
+            discordNotifier.sendError(DiscordErrorMessage.from(e, request, activeProfile(), getStackTrace(e)));
         }
 
         return ResponseEntity
@@ -105,7 +95,8 @@ public class GlobalExceptionHandler {
     }
 
     private String activeProfile() {
-        return String.join(",", environment.getActiveProfiles());
+        String[] profiles = environment.getActiveProfiles();
+        return (profiles.length > 0) ? profiles[0] : "";
     }
 
     private String getStackTrace(Exception e) {
@@ -120,6 +111,10 @@ public class GlobalExceptionHandler {
 
     private boolean isProd() {
         return Arrays.asList(environment.getActiveProfiles()).contains("prod");
+    }
+
+    private boolean isDev() {
+        return Arrays.asList(environment.getActiveProfiles()).contains("dev");
     }
 }
 

--- a/src/main/resources/templates/mail/withdrawal-notice.html
+++ b/src/main/resources/templates/mail/withdrawal-notice.html
@@ -142,7 +142,8 @@
                                     주식회사 <span th:text="${companyKorName}"></span> |
                                     사업자등록번호: <span th:text="${bizNumber}"></span> |
                                     대표: <span th:text="${ceoName}"></span><br />
-                                    <span th:text="${address}"></span> | 대표전화: <span th:text="${tel}"></span><br /><br />
+<!--                                    <span th:text="${address}"></span> | -->
+                                    대표전화: <span th:text="${tel}"></span><br /><br />
                                     &copy; <span th:text="${companyEngName}"></span> Corp. All Rights Reserved.
                                 </td>
                             </tr>


### PR DESCRIPTION
* [FIX] : OAuth 로그인 성공 시 프론트로 redirect

* [FEAT] : OAuth 링크 조회 API 개발

* [FIX] : 하드코딩 내용을 application.properties로 빼기

* [FIX] : 디스코드 알림 테스트 서버 / 실서버 분류해서 알림

* [FIX] : oauth 로그인 성공 시 redirect 부분 수정

* [FIX] : oauth 로그인 성공 시 redirect 부분 수정

## Changed
> 간단한 설명 (예: 로그인 완료 후 세션 동기화 누락 문제 해결)
수정 내용
   - 예) 로그인 성공 시 `store.setSession()` 호출 추가
   - 예) 기존 세션 초기화 로직 정리
---
## 📸 스크린샷 (선택)
<!-- UI 작업 시 스크린샷 첨부 -->

## 📎 관련 이슈(선택)
> 예: #숫자

---

## Todo
> 해당 PR 내용 관련해서 추후 해야할 일 

---
## Note
> 해당 PR관련해서 다른 작업자가 참고할 사항이 있다면 말해주세요!
> 예: npm i 로 oo 라이브 러리 설치 필요
