### PR TITLE
[FEAT] : 일정 시작 24시간 전 푸쉬 알림, 회원 정보 조회 시 발송되는 푸쉬 삭제(테스트용)

### DIFF
--- a/src/main/java/com/barogagi/batch/dto/ScheduleDTO.java
+++ b/src/main/java/com/barogagi/batch/dto/ScheduleDTO.java
@@ -1,0 +1,17 @@
+package com.barogagi.batch.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ScheduleDTO {
+
+    private String membershipNo;
+
+    private String scheduleNm;
+
+    private String planNm;
+
+    private String startTime;
+}

--- a/src/main/java/com/barogagi/batch/mapper/PushBatchMapper.java
+++ b/src/main/java/com/barogagi/batch/mapper/PushBatchMapper.java
@@ -1,0 +1,12 @@
+package com.barogagi.batch.mapper;
+
+import com.barogagi.batch.dto.ScheduleDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PushBatchMapper {
+
+    List<ScheduleDTO> selectSchedulePushTarget();
+}

--- a/src/main/java/com/barogagi/batch/scheduler/PushSchedular.java
+++ b/src/main/java/com/barogagi/batch/scheduler/PushSchedular.java
@@ -1,0 +1,29 @@
+package com.barogagi.batch.scheduler;
+
+import com.barogagi.batch.service.PushBatchService;
+import com.barogagi.sendMessage.service.CommonService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PushSchedular {
+
+    private final PushBatchService pushBatchService;
+    private final CommonService commonService;
+
+    // 일정 시작 24시간 전 안내 푸쉬
+    @Scheduled(cron = "0 0 * * * *")  // 정각
+    @SchedulerLock(
+            name = "startSchedulePushBatch",
+            lockAtMostFor = "1h",
+            lockAtLeastFor = "55m"
+    )
+    public void scheduleStartPushBatch() {
+        if(commonService.isProd()) {
+            pushBatchService.scheduleStartPushBatch();
+        }
+    }
+}

--- a/src/main/java/com/barogagi/batch/scheduler/WithdrawlScheduler.java
+++ b/src/main/java/com/barogagi/batch/scheduler/WithdrawlScheduler.java
@@ -1,26 +1,19 @@
 package com.barogagi.batch.scheduler;
 
 import com.barogagi.batch.service.WithdrawalBatchService;
+import com.barogagi.sendMessage.service.CommonService;
+import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class WithdrawlScheduler {
 
     private final WithdrawalBatchService withdrawalBatchService;
-
-    private final String IS_WITHDRAW_MEMBER_FLAG;  // 탈퇴 처리 배치 flag
-    private final String IS_PRE_WITHDRAWAL_NOTICE_FLAG;  // 탈퇴 처리 전 사전 고지 flag
-    private final String IS_CHANGE_STATUS_FLAG;  // 상태 변경 flag
-
-    public WithdrawlScheduler(Environment environment, WithdrawalBatchService withdrawalBatchService) {
-        this.withdrawalBatchService = withdrawalBatchService;
-        this.IS_WITHDRAW_MEMBER_FLAG = environment.getRequiredProperty("withdraw.member");
-        this.IS_PRE_WITHDRAWAL_NOTICE_FLAG = environment.getRequiredProperty("pre.withdrawal.notice");
-        this.IS_CHANGE_STATUS_FLAG = environment.getRequiredProperty("change.status");
-    }
+    private final CommonService commonService;
 
     // 탈퇴 처리
     @Scheduled(cron = "0 0 9 * * *") // 09:00
@@ -30,7 +23,7 @@ public class WithdrawlScheduler {
             lockAtLeastFor = "1m"
     )
     public void runWithdrawalBatch() {
-        if(Boolean.parseBoolean(IS_WITHDRAW_MEMBER_FLAG)) {
+        if(commonService.isProd()) {
             withdrawalBatchService.processWithdrawlBatch();
         }
     }
@@ -43,7 +36,7 @@ public class WithdrawlScheduler {
             lockAtLeastFor = "55m"
     )
     public void beforeWithdrawalBatch() {
-        if(Boolean.parseBoolean(IS_PRE_WITHDRAWAL_NOTICE_FLAG)) {
+        if(commonService.isProd()) {
             withdrawalBatchService.processBeforeWithdrawlBatch();
         }
     }
@@ -55,7 +48,7 @@ public class WithdrawlScheduler {
             lockAtLeastFor = "25m"
     )
     public void changeStatusBatch() {
-        if(Boolean.parseBoolean(IS_CHANGE_STATUS_FLAG)) {
+        if(commonService.isProd()) {
             withdrawalBatchService.changeStatusBatch();
         }
     }

--- a/src/main/java/com/barogagi/batch/service/PushBatchService.java
+++ b/src/main/java/com/barogagi/batch/service/PushBatchService.java
@@ -1,0 +1,36 @@
+package com.barogagi.batch.service;
+
+import com.barogagi.batch.dto.ScheduleDTO;
+import com.barogagi.batch.mapper.PushBatchMapper;
+import com.barogagi.push.service.PushService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushBatchService {
+
+    private final PushService pushService;
+
+    private final PushBatchMapper pushBatchMapper;
+
+    // 일정 시작 24시간 전 푸쉬 알림
+    public void scheduleStartPushBatch() {
+
+        // 1. 타켓 조회
+        List<ScheduleDTO> targets = pushBatchMapper.selectSchedulePushTarget();
+
+        // 푸쉬 일괄 발송
+        for(ScheduleDTO scheduleDTO : targets) {
+
+            String title = "내일 예정된 일정이 있습니다";
+            String body = String.format("[%s] 일정이 하루 앞으로 다가왔습니다.", scheduleDTO.getScheduleNm());
+
+            pushService.sendToUser(scheduleDTO.getMembershipNo(), title, body);
+        }
+    }
+}

--- a/src/main/java/com/barogagi/member/info/service/MemberService.java
+++ b/src/main/java/com/barogagi/member/info/service/MemberService.java
@@ -33,7 +33,6 @@ public class MemberService {
     private final InputValidate inputValidate;
     private final UserMembershipRepository userMembershipRepository;
     private final MemberTxService memberTxService;
-    private final PushService pushService;
     private final Validator validator;
 
     public ApiResponse getUserInfo(HttpServletRequest request) {
@@ -62,9 +61,6 @@ public class MemberService {
 
         // 비밀번호는 보내주지 않는다
         memberInfo.setPassword("");
-
-        // 푸쉬
-        pushService.sendToUser(membershipNo, "회원 정보 조회", "회원 정보 조회가 완료되었습니다.");
 
         return ApiResponse.resultData(
                 memberInfo,

--- a/src/main/resources/mapper/PushBatchMapper.xml
+++ b/src/main/resources/mapper/PushBatchMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.barogagi.batch.mapper.PushBatchMapper">
+    <select id="selectSchedulePushTarget" resultType="com.barogagi.batch.dto.ScheduleDTO">
+        <![CDATA[
+            SELECT s.MEMBERSHIP_NO AS membershipNo
+                 , s.SCHEDULE_NM AS scheduleNm
+                 , p.PLAN_NM AS planNm
+                 , p.START_TIME AS startTime
+            FROM SCHEDULE s
+            JOIN PLAN p ON s.SCHEDULE_NUM = p.SCHEDULE_NUM
+            WHERE DATE_FORMAT(CURDATE() + INTERVAL 1 DAY, '%Y-%m-%d') BETWEEN s.START_DATE AND s.END_DATE
+              AND p.START_TIME = (
+                    SELECT MIN(p2.START_TIME)
+                    FROM PLAN p2
+                    WHERE p2.SCHEDULE_NUM = s.SCHEDULE_NUM
+                      AND p2.DEL_YN = 'N'
+                  )
+              AND HOUR(STR_TO_DATE(p.START_TIME, '%H:%i')) = HOUR(NOW())
+              AND s.DEL_YN = 'N'
+              AND p.DEL_YN = 'N'
+        ]]>
+    </select>
+</mapper>


### PR DESCRIPTION
## Changed
> 간단한 설명 (예: 로그인 완료 후 세션 동기화 누락 문제 해결)
수정 내용
   - 일정 시작 24시간 전 푸쉬 알림, 회원 정보 조회 시 발송되는 푸쉬 삭제(테스트용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약된 푸시 알림 시스템 추가 - 일정 정보를 기반으로 매시간 정각에 사용자에게 자동 알림 발송

* **개선사항**
  * 배치 작업의 프로덕션 환경 제어 강화 - 프로덕션 환경에서만 배치 처리 실행
  * 사용자 정보 조회 시 불필요한 알림 발송 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->